### PR TITLE
Remember scroll position when switching between categories

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -1,9 +1,9 @@
-import Ember from 'ember';
+import Application from 'ember-application';
 import Resolver from './resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from './config/environment';
 
-const App = Ember.Application.extend({
+const App = Application.extend({
   modulePrefix: config.modulePrefix,
   podModulePrefix: config.podModulePrefix,
   Resolver

--- a/app/components/hn-item/component.js
+++ b/app/components/hn-item/component.js
@@ -1,6 +1,7 @@
-import Ember from 'ember';
+import Component from 'ember-component';
 import computed from 'ember-computed';
-export default Ember.Component.extend({
+
+export default Component.extend({
   tagName: 'article',
 
   itemID: null,

--- a/app/components/hn-item/template.hbs
+++ b/app/components/hn-item/template.hbs
@@ -14,11 +14,11 @@
   </p>
 </div>
 <div class="Comments">
-  {{#link-to "item" itemID~}}
+  {{#link-to "item" itemID}}
     {{#if commentsCount}}
       {{commentsCount}}
     {{else}}
       <span></span>
     {{/if}}
-  {{~/link-to~}}
+  {{/link-to}}
 </div>

--- a/app/routes/about.js
+++ b/app/routes/about.js
@@ -1,4 +1,4 @@
-import Ember from 'ember';
+import Route from 'ember-route';
 
-export default Ember.Route.extend({
+export default Route.extend({
 });

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -1,5 +1,8 @@
+import Ember from 'ember';
 import Route from 'ember-route';
 import fetch from 'fetch';
+
+const { run, getWithDefault } = Ember;
 
 export default Route.extend({
   apiHost: 'https://node-hnapi.herokuapp.com',
@@ -18,5 +21,20 @@ export default Route.extend({
 
   resetController(controller) {
     controller.set('items', []);
+  },
+
+  lastScroll: 0,
+
+  activate() {
+    this._super(...arguments);
+    run.next(() => window.scrollTo(0, this.get('lastScroll')));
+  },
+
+  actions: {
+    willTransition() {
+      this._super(...arguments);
+      let lastScroll = getWithDefault(window || {}, 'scrollY', 0);
+      this.set('lastScroll', lastScroll);
+    }
   }
 });

--- a/app/routes/item.js
+++ b/app/routes/item.js
@@ -1,5 +1,8 @@
+import Ember from 'ember';
 import fetch from 'fetch';
 import Route from 'ember-route';
+
+const { run } = Ember;
 
 export default Route.extend({
   apiHost: 'https://node-hnapi.herokuapp.com',
@@ -12,6 +15,10 @@ export default Route.extend({
 
   setupController(controller, item) {
     controller.setProperties({ item });
-  }
+  },
 
+  activate() {
+    this._super(...arguments);
+    run.next(() => window.scrollTo(0, 0));
+  }
 });

--- a/tests/helpers/destroy-app.js
+++ b/tests/helpers/destroy-app.js
@@ -1,5 +1,7 @@
 import Ember from 'ember';
 
+const { run } = Ember;
+
 export default function destroyApp(application) {
-  Ember.run(application, 'destroy');
+  run(application, 'destroy');
 }

--- a/tests/helpers/start-app.js
+++ b/tests/helpers/start-app.js
@@ -2,11 +2,13 @@ import Ember from 'ember';
 import Application from '../../app';
 import config from '../../config/environment';
 
-export default function startApp(attrs) {
-  let attributes = Ember.merge({}, config.APP);
-  attributes = Ember.merge(attributes, attrs); // use defaults, but you can override;
+const { merge, run } = Ember;
 
-  return Ember.run(() => {
+export default function startApp(attrs) {
+  let attributes = merge({}, config.APP);
+  attributes = merge(attributes, attrs); // use defaults, but you can override;
+
+  return run(() => {
     let application = Application.create(attributes);
     application.setupForTesting();
     application.injectTestHelpers();


### PR DESCRIPTION
Currently when the user switches between categories their last scroll position is lost, which makes for a frustrating user experience.

This PR saves the scroll position of each category when leaving the route (`willTransition`), and then restores it on re-entry.

The exception is the `item` route, which will now always returns to the top to begin reading.