### PR TITLE
Guard against items null scores and job items

### DIFF
--- a/app/components/hn-item/component.js
+++ b/app/components/hn-item/component.js
@@ -1,9 +1,14 @@
-import Ember from 'ember';
+import Component from 'ember-component';
 import computed from 'ember-computed';
-export default Ember.Component.extend({
+
+const { equal } = computed;
+
+export default Component.extend({
   tagName: 'article',
 
   itemID: null,
+
+  type: null,
 
   position: 1,
 
@@ -20,6 +25,12 @@ export default Ember.Component.extend({
   commentsCount: 0,
 
   time: 0,
+
+  isJob: equal('type', 'job'),
+
+  safeScore: computed('score', function() {
+  	return this.get('score') || 0;
+  }),
 
   isSelfLink: computed('url', {
     get() {

--- a/app/components/hn-item/template.hbs
+++ b/app/components/hn-item/template.hbs
@@ -7,10 +7,14 @@
       <a href={{url}}>{{title}}</a>
     {{/if}}
 
-    {{#if domain}}<span class="domain">({{domain}})</span>{{/if~}}
+    {{#if domain}}<span class="domain">({{domain}})</span>{{/if}}
   </h2>
   <p>
-    <span>{{pluralize score "point"}} by {{by}} {{time-format timestamp}}</span>
+  	{{#if isJob}}
+  		<span>{{time-format timestamp}}</span>
+  	{{else}}
+    	<span>{{pluralize safeScore "point"}} by {{by}} {{time-format timestamp}}</span>
+    {{/if}}
   </p>
 </div>
 <div class="Comments">

--- a/app/components/news-list/template.hbs
+++ b/app/components/news-list/template.hbs
@@ -1,6 +1,7 @@
 {{#each items key="id" as |item|}}
   {{hn-item
     itemID=(unbound item.id)
+    type=(unbound item.type)
     position=(unbound item.position)
     url=(unbound item.url)
     domain=(unbound item.domain)


### PR DESCRIPTION
Some posts don't yet have points. Then this happens the UI renders `null points`.
This PR guards against this situation by defaulting null values to 0.

It also only displayed the posted date for a `job` item, as they don't ever seem to have a `by` or `score`.